### PR TITLE
Add charging source to the message format

### DIFF
--- a/msg/SmartBatteryStatus.msg
+++ b/msg/SmartBatteryStatus.msg
@@ -1,6 +1,12 @@
+# Charging state
 uint8 DISCHARGING = 0
 uint8 CHARGING    = 1
 uint8 CHARGED     = 2
+
+# Charging source
+uint8 CHARGING_SOURCE_NONE = 0
+uint8 CHARGING_SOURCE_DOCK = 1
+uint8 CHARGING_SOURCE_JACK = 2
 
 Header  header
 float32 voltage          # Voltage in Volts
@@ -10,4 +16,6 @@ float32 capacity         # Capacity in Ah (last full capacity)
 float32 design_capacity  # Capacity in Ah (design capacity)
 int32   percentage       # Charge percentage
 uint8   charge_state     # Enum 
-bool    present          # Should be an error if battery is not present
+uint8   charging_source  # Enum
+bool    present          # Should be false if battery is not present
+


### PR DESCRIPTION
Could have added the identifier as a string to allow more flexibility, but can't really foresee a use case where the enum list here is longer than a few items.

Can change to a string in future if we really need to, but until then, lightweight I think is better.